### PR TITLE
[음정민] 카카오 로그인 api

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,8 @@
-import jwt
-
-from functools import wraps
+from functools   import wraps
 from django.http import JsonResponse
+
+import jwt
+import requests
 from django.conf import settings
 
 from users.models import User
@@ -25,3 +26,57 @@ def check_access(func):
         return func(self, request)
 
     return wrapper
+
+class KakaoAPI:
+    def __init__(self, rest_api_key, redirect_uri, client_secret):
+        self.rest_api_key  = rest_api_key
+        self.redirect_uri  = redirect_uri
+        self.client_secret = client_secret
+
+    def get_kakao_token(self, authorize_code):
+        KAKAO_TOKEN_URL = 'https://kauth.kakao.com/oauth/token'
+        headers         = {'Content-Type' : 'application/x-www-form-urlencoded'}
+        data            = {
+            'grant_type'   : 'authorization_code',
+            'client_id'    : self.rest_api_key,
+            'redirect_uri' : self.redirect_uri,
+            'code'         : authorize_code,
+            'client_secret': self.client_secret
+        }
+
+        response = requests.post(KAKAO_TOKEN_URL, headers=headers, data=data)
+
+        if not response.ok:
+            raise ValueError('INVALID_KAKAO_AUTH_CODE')
+
+        data         = response.json()
+        access_token = data.get('access_token')
+
+        return access_token
+
+    def get_kakao_profile(self, access_token):
+        KAKAO_PROFILE_URL = 'https://kapi.kakao.com/v2/user/me'
+        KAKAO_SIGNOUT_URL = 'https://kapi.kakao.com/v1/user/unlink'
+
+        profile_headers  = {'Authorization':f'Bearer {access_token}'}
+        profile_response = requests.get(KAKAO_PROFILE_URL, headers = profile_headers)
+
+        if not profile_response.ok:
+            raise ValueError('INVALID_KAKAO_ACCESS_TOKEN')
+
+        profile = profile_response.json()
+
+        signout_headers = {
+            'Content-Type' : 'application/x-www-form-urlencoded',
+            'Authorization': f'Bearer {access_token}'
+            }
+        signout_response = requests.post(KAKAO_SIGNOUT_URL, headers=signout_headers)
+
+        if not signout_response.ok:
+            raise ValueError('FAIL_KAKAO_SIGN_OUT')
+
+        return profile
+
+def create_token(value):
+    access_token = jwt.encode({'id':value}, settings.SECRET_KEY, settings.ALGORITHM)
+    return access_token

--- a/myhoneytrip/settings.py
+++ b/myhoneytrip/settings.py
@@ -1,6 +1,6 @@
 from pathlib     import Path
 
-from my_settings import DATABASES, SECRET_KEY
+from my_settings import ALGORITHM, DATABASES, SECRET_KEY, KAKAO_REDIRECT_URI, KAKAO_REST_API_KEY, KAKAO_CLIENT_SECRET
 
 import pymysql
 
@@ -9,6 +9,8 @@ pymysql.install_as_MySQLdb()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = SECRET_KEY
+
+ALGORITHM = ALGORITHM
 
 DEBUG = True
 
@@ -26,6 +28,7 @@ INSTALLED_APPS = [
     'flights',
     'users',
     'core',
+    'django_extensions'
 ]
 
 MIDDLEWARE = [
@@ -114,3 +117,7 @@ CORS_ALLOW_HEADERS = (
     'x-csrftoken',
     'x-requested-with',    		
 )
+
+KAKAO_REDIRECT_URI  = KAKAO_REDIRECT_URI
+KAKAO_REST_API_KEY  = KAKAO_REST_API_KEY
+KAKAO_CLIENT_SECRET = KAKAO_CLIENT_SECRET

--- a/myhoneytrip/urls.py
+++ b/myhoneytrip/urls.py
@@ -1,4 +1,5 @@
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    path('users', include('users.urls'))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django==4.0.6
 django-cors-headers==3.13.0
 mysqlclient==2.1.1
 PyMySQL==1.0.2
+PyJWT==2.4.0
+requests==2.28.1

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,163 @@
-from django.test import TestCase
+import json
+from django.test   import TestCase, Client
+from unittest.mock import patch, MagicMock
 
-# Create your tests here.
+from users.models import User
+from core.utils   import create_token
+
+class KakaoSigninTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id       = 1,
+            name     = '닉넴1',
+            kakao_id = '1234'
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch('users.views.KakaoAPI')
+    def test_success_kakao_signup_and_signin(self, mocked_kakao_api):
+        client = Client()
+        
+        class MockedKakaoResponse:
+            def get_kakao_token(self, code):
+                return 'mocked_access_token'
+
+            def get_kakao_profile(self, token):
+                return {
+                    "id":123456789,
+                    "kakao_account": { 
+                        "profile_needs_agreement": False,
+                        "profile": {
+                            "nickname": "홍길동",
+                            "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+                            "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+                            "is_default_image":False
+                        },
+                        "name_needs_agreement":False, 
+                        "name":"홍길동",
+                        "email_needs_agreement":False, 
+                        "is_email_valid": True,   
+                        "is_email_verified": True,
+                        "email": "sample@sample.com",
+                        "age_range_needs_agreement":False,
+                        "age_range":"20~29",
+                        "birthday_needs_agreement":False,
+                        "birthday":"1130",
+                        "gender_needs_agreement":False,
+                        "gender":"female"
+                    },  
+                }
+
+        mocked_kakao_api.return_value = MockedKakaoResponse()
+
+        body     = {'authorize_code':'mocked_auth_code'}
+        response = client.post('/users/signin/kakao', json.dumps(body), content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message': 'SUCCESS', 
+                'token': create_token(2), 
+                'name': '홍길동'
+                }
+            )
+
+    @patch('users.views.KakaoAPI')
+    def test_success_kakao_signin(self, mocked_kakao_api):
+        client = Client()
+        
+        class MockedKakaoResponse:
+            def get_kakao_token(self, code):
+                return 'mocked_access_token'
+
+            def get_kakao_profile(self, token):
+                return {
+                    "id":1234,
+                    "kakao_account": { 
+                        "profile_needs_agreement": False,
+                        "profile": {
+                            "nickname": "닉넴1",
+                            "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+                            "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+                            "is_default_image":False
+                        },
+                        "name_needs_agreement":False, 
+                        "name":"홍길동",
+                        "email_needs_agreement":False, 
+                        "is_email_valid": True,   
+                        "is_email_verified": True,
+                        "email": "sample@sample.com",
+                        "age_range_needs_agreement":False,
+                        "age_range":"20~29",
+                        "birthday_needs_agreement":False,
+                        "birthday":"1130",
+                        "gender_needs_agreement":False,
+                        "gender":"female"
+                    },  
+                }
+
+        mocked_kakao_api.return_value = MockedKakaoResponse()
+
+        body     = {'authorize_code':'mocked_auth_code'}
+        response = client.post('/users/signin/kakao', json.dumps(body), content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+                'message': 'SUCCESS', 
+                'token': create_token(1), 
+                'name': '닉넴1'
+                }
+            )
+
+    @patch('core.utils.requests')
+    def test_fail_invalid_kakao_auth_code(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponseToken:
+            def json(self):
+                return {
+                    'error': 'invalid_grant', 
+                    'error_description': 'authorization code not found for code=----', 
+                    'error_code': 'KOE320'
+                }
+            ok = False
+
+        mocked_requests.post = MagicMock(return_value = MockedResponseToken())
+        
+        body     = {'authorize_code':'mocked_auth_code'}
+        response = client.post('/users/signin/kakao', json.dumps(body), content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message': 'INVALID_KAKAO_AUTH_CODE'})
+
+
+    @patch('core.utils.requests')
+    def test_fail_invalid_kakao_access_token(self, mocked_requests):
+        client = Client()
+
+        class MockedResponseProfile:
+            def json(self):
+                return {
+                    'error': 'invalid_grant', 
+                    'error_description': 'authorization code not found for code=----', 
+                    'error_code': 'KOE320'
+                }
+            ok = False
+
+        mocked_requests.get  = MagicMock(return_value = MockedResponseProfile())
+        body     = {'authorize_code':'mocked_auth_code'}
+        response = client.post('/users/signin/kakao', json.dumps(body), content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message': 'INVALID_KAKAO_ACCESS_TOKEN'})
+
+    def test_fail_key_error(self):
+        client = Client()
+
+        body = {'auth_code':'mocked_auth_code'}
+
+        response = client.post('/users/signin/kakao', json.dumps(body), content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message':'KEY_ERROR'})

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import KakaoSignInView
+
+urlpatterns = [
+    path('/signin/kakao', KakaoSignInView.as_view()),
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+import json
+from django.http  import JsonResponse
+from django.views import View
 
-# Create your views here.
+from django.conf  import settings
+from core.utils import KakaoAPI, create_token
+from .models    import User
+
+class KakaoSignInView(View):
+    def post(self, request):
+        try:
+            kakao_authorize_code = json.loads(request.body)['authorize_code']
+
+            kakao_api = KakaoAPI(
+                settings.KAKAO_REST_API_KEY, 
+                settings.KAKAO_REDIRECT_URI, 
+                settings.KAKAO_CLIENT_SECRET)
+
+            kakao_access_token = kakao_api.get_kakao_token(kakao_authorize_code)
+            kakao_profile      = kakao_api.get_kakao_profile(kakao_access_token)
+
+            kakao_id = kakao_profile['id']
+            name     = kakao_profile['kakao_account']['profile']['nickname']
+            email    = kakao_profile['kakao_account'].get('email')
+
+            if not User.objects.filter(kakao_id=kakao_id).exists():
+                User.objects.create(name=name, email=email, kakao_id=kakao_id)
+
+            user = User.objects.get(kakao_id=kakao_id)
+
+            return JsonResponse({'message': 'SUCCESS', 'token': create_token(user.id), 'name': user.name}, status=200)
+
+        except KeyError:
+            return JsonResponse({'message': 'KEY_ERROR'}, status=400)
+        except ValueError as e:
+            return JsonResponse({'message': str(e)}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 로그인api이용한 소셜 로그인 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 회원가입 로그인
- 요청으로 들어온 카카오 인가코드로 카카오 토큰을 받는다.
- 카카오 토큰으로 카카오 유저정보를 확인한다.
- 우리 서버의 유저 정보와 비교해서 회원이 아니면 회원가입후 로그인(토큰발급)
- 회원이면 바로 로그인

2. 테스트코드 작성
- 성공) 카카오 회원가입&로그인
- 성공) 기존 유저 카카오 로그인
- 실패) 잘못된 카카오 인가코드
- 실패) 잘못된 카카오 토큰
- 실패) 키에러

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- requests이용해서 다른 서버에 요청 보내는 법을 배웠습니다.
- 테스트코드 작성법

<br />

## :: 기타 질문 및 특이 사항
- patch를 이용해서 requests를 목데이터로 처리했는데 한번에 여러데이터를 patch할수 있나요?
- 키에러 경우가 여러가지인데 한가지 키에러에 대해서만 테스트코드를 작성했는데 나머지 경우에 대해서도 작성해야하나요?
- 현재는 회원가입때만 닉네임을 데이터베이스에 저장하고 이후에 로그인때는 카카오 아이디만 비교해서 유저확인을 하고 바로 로그인을 시키는데 카카오 닉네임이 변경된 경우에 데이터베이스에 반영하는 코드를 추가해야겠죠..?
